### PR TITLE
ResultSet.normalizePivotConfig() fix

### DIFF
--- a/packages/cubejs-client-core/src/ResultSet.js
+++ b/packages/cubejs-client-core/src/ResultSet.js
@@ -60,13 +60,13 @@ export default class ResultSet {
   normalizePivotConfig(pivotConfig) {
     const query = this.loadResponse.query;
     let timeDimensions = (query.timeDimensions || []).filter(td => !!td.granularity);
-    pivotConfig = pivotConfig || timeDimensions.length ? {
+    pivotConfig = pivotConfig || (timeDimensions.length ? {
       x: timeDimensions.map(td => td.dimension),
       y: query.dimensions || []
     } : {
       x: query.dimensions || [],
       y: []
-    };
+    });
     if (!pivotConfig.x.concat(pivotConfig.y).find(d => d === 'measures')) {
       pivotConfig.y = pivotConfig.y.concat(['measures']);
     }


### PR DESCRIPTION
Add parentheses to the condition. Without parentheses, it will always create new pivotConfig when timeDimension is present. It makes impossible to pass custom configuration to `pivot()` and `chartPivot()`.