### PR TITLE
Dot env tests

### DIFF
--- a/packages/cubejs-cli/README.md
+++ b/packages/cubejs-cli/README.md
@@ -14,6 +14,16 @@ cubejs create hello-world -d postgres
 
 [Learn more](https://github.com/statsbotco/cube.js#getting-started)
 
+## Tests
+
+Tests should be run as part of the `pre-commit` hook for any changes to this package.
+
+You can run tests manually by running
+
+```bash
+npm test
+```
+
 ### License
 
 Cube.js CLI is [Apache 2.0 licensed](./LICENSE).

--- a/packages/cubejs-cli/package.json
+++ b/packages/cubejs-cli/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "eslint": "^4.14.0",
     "eslint-plugin-node": "^5.2.1",
+    "jest": "^23.6.0",
     "mocha": "^5.2.0",
     "should": "^13.2.3"
   },

--- a/packages/cubejs-cli/package.json
+++ b/packages/cubejs-cli/package.json
@@ -10,7 +10,12 @@
     "cubejs": "./index.js"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "jest"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm test"
+    }
   },
   "files": [
     "index.js",
@@ -31,6 +36,7 @@
   "devDependencies": {
     "eslint": "^4.14.0",
     "eslint-plugin-node": "^5.2.1",
+    "husky": "^1.3.1",
     "jest": "^23.6.0",
     "mocha": "^5.2.0",
     "should": "^13.2.3"

--- a/packages/cubejs-cli/templates.js
+++ b/packages/cubejs-cli/templates.js
@@ -12,8 +12,7 @@ const handlerJs = `module.exports = require('@cubejs-backend/serverless');
 
 // Shared environment variables, across all DB types
 const sharedDotEnvVars = env => `CUBEJS_DB_TYPE=${env.dbType}
-CUBEJS_API_SECRET=${env.apiSecret}
-`;
+CUBEJS_API_SECRET=${env.apiSecret}`;
 
 const athenaDotEnvVars = env => `CUBEJS_AWS_KEY=<YOUR ATHENA AWS KEY HERE>
 CUBEJS_AWS_SECRET=<YOUR ATHENA SECRET KEY HERE>
@@ -146,3 +145,7 @@ exports.serverless = {
   },
   dependencies: ['@cubejs-backend/serverless']
 };
+
+module.exports = {
+  dotEnv,
+}

--- a/packages/cubejs-cli/templates.test.js
+++ b/packages/cubejs-cli/templates.test.js
@@ -1,0 +1,43 @@
+
+const { dotEnv } = require("./templates")
+
+const apiSecret = 123
+const generateTestEnv = (apiSecret, dbType) => ({ apiSecret, dbType})
+
+test('dotEnv should return default env vars for mysql DB type', () => {
+    const dbType = 'mysql'
+    const expectedDotEnvVars = `CUBEJS_DB_HOST=<YOUR_DB_HOST_HERE>
+CUBEJS_DB_NAME=<YOUR_DB_NAME_HERE>
+CUBEJS_DB_USER=<YOUR_DB_USER_HERE>
+CUBEJS_DB_PASS=<YOUR_DB_PASS_HERE>
+CUBEJS_DB_TYPE=${dbType}
+CUBEJS_API_SECRET=${apiSecret}`
+
+    expect(dotEnv(generateTestEnv(apiSecret, dbType))).toBe(expectedDotEnvVars)
+})
+
+test('dotEnv should return default env vars for unsupported DB type', () => {
+    const dbType = 'unsupported'
+    const expectedDotEnvVars = `CUBEJS_DB_HOST=<YOUR_DB_HOST_HERE>
+CUBEJS_DB_NAME=<YOUR_DB_NAME_HERE>
+CUBEJS_DB_USER=<YOUR_DB_USER_HERE>
+CUBEJS_DB_PASS=<YOUR_DB_PASS_HERE>
+CUBEJS_DB_TYPE=${dbType}
+CUBEJS_API_SECRET=${apiSecret}`
+
+    expect(dotEnv(generateTestEnv(apiSecret, dbType))).toBe(expectedDotEnvVars)
+})
+
+test('dotEnv should return Athena-specific env vars for Athena DB type', () => {
+    const dbType = 'athena'
+    const expectedDotEnvVars = `CUBEJS_AWS_KEY=<YOUR ATHENA AWS KEY HERE>
+CUBEJS_AWS_SECRET=<YOUR ATHENA SECRET KEY HERE>
+CUBEJS_AWS_REGION=<AWS REGION STRING, e.g. us-east-1>
+# You can find the Athena S3 Output location here: https://docs.aws.amazon.com/athena/latest/ug/querying.html
+CUBEJS_AWS_S3_OUTPUT_LOCATION=<S3 OUTPUT LOCATION>
+CUBEJS_JDBC_DRIVER=athena
+CUBEJS_DB_TYPE=${dbType}
+CUBEJS_API_SECRET=${apiSecret}`
+
+    expect(dotEnv(generateTestEnv(apiSecret, dbType))).toBe(expectedDotEnvVars)
+})


### PR DESCRIPTION
* Adding Jest tests for the cubejs-cli changes to the way we generate dot env vars
* Removing extraneous newline on `sharedDotEnvVars` in `templates.js`, exporting `dotEnv` in `module.exports` (new export)
* Adding husky pre-commit hook for `npm test`