### PR TITLE
Make API path namespace configurable

### DIFF
--- a/docs/Cube.js-Backend/@cubejs-backend-server-core.md
+++ b/docs/Cube.js-Backend/@cubejs-backend-server-core.md
@@ -19,7 +19,7 @@ Create an instance of `CubejsServerCore` to embed it in an `Express` application
     * `logger(msg, params)` - Pass function for your custom logger.
     * `schemaPath` - Path to the `schema` location. By default, it is `/schema`.
     * `devServer` - Enable development server. By default, it is `true`.
-    * `baseRoute` - Route where _Cube.js_ is mounted to. By default, it is `/cubejs-api`.
+    * `basePath` - Path where _Cube.js_ is mounted to. By default, it is `/cubejs-api`.
     * `checkAuthMiddleware` - Pass express-style middleware to check authentication. Set `req.authInfo = { u: { ...userContextObj } }` inside middleware if you want to provide `USER_CONTEXT`. [Learn more](/cube#context-variables-user-context).
 
 ```javascript

--- a/docs/Cube.js-Backend/@cubejs-backend-server-core.md
+++ b/docs/Cube.js-Backend/@cubejs-backend-server-core.md
@@ -13,12 +13,13 @@ Express application.
 
 Create an instance of `CubejsServerCore` to embed it in an `Express` application.
 
-* `options` - options object.
+* `options` - Options object.
     * `dbType` - Type of your database.
-    * `driverFactory()` - pass function of the driver factory with your database type.
-    * `logger(msg, params)` - pass function for your custom logger.
+    * `driverFactory()` - Pass function of the driver factory with your database type.
+    * `logger(msg, params)` - Pass function for your custom logger.
     * `schemaPath` - Path to the `schema` location. By default, it is `/schema`.
     * `devServer` - Enable development server. By default, it is `true`.
+    * `baseRoute` - Route where _Cube.js_ is mounted to. By default, it is `/cubejs-api`.
     * `checkAuthMiddleware` - Pass express-style middleware to check authentication. Set `req.authInfo = { u: { ...userContextObj } }` inside middleware if you want to provide `USER_CONTEXT`. [Learn more](/cube#context-variables-user-context).
 
 ```javascript

--- a/packages/cubejs-api-gateway/index.js
+++ b/packages/cubejs-api-gateway/index.js
@@ -190,10 +190,11 @@ class ApiGateway {
     this.adapterApi = adapterApi;
     this.logger = logger;
     this.checkAuthMiddleware = options.checkAuthMiddleware || this.checkAuth.bind(this);
+    this.baseRoute = options.baseRoute || '/cubejs-api';
   }
 
   initApp(app) {
-    app.get('/cubejs-api/v1/load', this.checkAuthMiddleware, (async (req, res) => {
+    app.get(`${this.baseRoute}/v1/load`, this.checkAuthMiddleware, (async (req, res) => {
       try {
         const query = JSON.parse(req.query.query);
         this.log(req, {
@@ -232,7 +233,7 @@ class ApiGateway {
       }
     }));
 
-    app.get('/cubejs-api/v1/sql', this.checkAuthMiddleware, (async (req, res) => {
+    app.get(`${this.baseRoute}/v1/sql`, this.checkAuthMiddleware, (async (req, res) => {
       try {
         const query = JSON.parse(req.query.query);
         const normalizedQuery = normalizeQuery(query);
@@ -245,7 +246,7 @@ class ApiGateway {
       }
     }));
 
-    app.get('/cubejs-api/v1/meta', this.checkAuthMiddleware, (async (req, res) => {
+    app.get(`${this.baseRoute}/v1/meta`, this.checkAuthMiddleware, (async (req, res) => {
       try {
         const metaConfig = await this.compilerApi.metaConfig();
         const cubes = metaConfig.map(c => c.config);

--- a/packages/cubejs-api-gateway/index.js
+++ b/packages/cubejs-api-gateway/index.js
@@ -190,11 +190,11 @@ class ApiGateway {
     this.adapterApi = adapterApi;
     this.logger = logger;
     this.checkAuthMiddleware = options.checkAuthMiddleware || this.checkAuth.bind(this);
-    this.baseRoute = options.baseRoute || '/cubejs-api';
+    this.basePath = options.basePath || '/cubejs-api';
   }
 
   initApp(app) {
-    app.get(`${this.baseRoute}/v1/load`, this.checkAuthMiddleware, (async (req, res) => {
+    app.get(`${this.basePath}/v1/load`, this.checkAuthMiddleware, (async (req, res) => {
       try {
         const query = JSON.parse(req.query.query);
         this.log(req, {
@@ -233,7 +233,7 @@ class ApiGateway {
       }
     }));
 
-    app.get(`${this.baseRoute}/v1/sql`, this.checkAuthMiddleware, (async (req, res) => {
+    app.get(`${this.basePath}/v1/sql`, this.checkAuthMiddleware, (async (req, res) => {
       try {
         const query = JSON.parse(req.query.query);
         const normalizedQuery = normalizeQuery(query);
@@ -246,7 +246,7 @@ class ApiGateway {
       }
     }));
 
-    app.get(`${this.baseRoute}/v1/meta`, this.checkAuthMiddleware, (async (req, res) => {
+    app.get(`${this.basePath}/v1/meta`, this.checkAuthMiddleware, (async (req, res) => {
       try {
         const metaConfig = await this.compilerApi.metaConfig();
         const cubes = metaConfig.map(c => c.config);

--- a/packages/cubejs-server-core/core/index.js
+++ b/packages/cubejs-server-core/core/index.js
@@ -124,6 +124,7 @@ class CubejsServerCore {
       this.compilerApi,
       this.orchestratorApi,
       this.logger, {
+        baseRoute: this.options.baseRoute,
         checkAuthMiddleware: this.options.checkAuthMiddleware
       }
     );

--- a/packages/cubejs-server-core/core/index.js
+++ b/packages/cubejs-server-core/core/index.js
@@ -124,7 +124,7 @@ class CubejsServerCore {
       this.compilerApi,
       this.orchestratorApi,
       this.logger, {
-        baseRoute: this.options.baseRoute,
+        basePath: this.options.basePath,
         checkAuthMiddleware: this.options.checkAuthMiddleware
       }
     );


### PR DESCRIPTION
Now it's possible to customize your route like
- `http://localhost:8080/cubejs-api/v1/load?query=...` (default)
- `http://localhost:8080/my-custom-route/v1/load?query=...`

I'm still not fully satisfied with the versioning. In my opinion the endpoint should be like this `http://localhost:8080/my-custom-route/v1/cubejs/load?query=...` where `cubejs` should also be customizable.

But this format is not possible at the moment 🤔 How could we solve this?