### PR TITLE
fix: client-react - query prop now has default blank value

### DIFF
--- a/packages/cubejs-react/src/QueryRenderer.jsx
+++ b/packages/cubejs-react/src/QueryRenderer.jsx
@@ -85,8 +85,12 @@ export default class QueryRenderer extends React.Component {
 QueryRenderer.propTypes = {
   render: PropTypes.func,
   afterRender: PropTypes.func,
-  cubejsApi: PropTypes.object,
+  cubejsApi: PropTypes.object.isRequired,
   query: PropTypes.object,
   queries: PropTypes.object,
   loadSql: PropTypes.any
 };
+
+QueryRender.defaultProps = {
+  query: {}
+}


### PR DESCRIPTION
No need to pass redundant blank query to QueryBuilder.
Also, mark cubejsApi prop as required.