### PR TITLE
In cubejs-schema-compiler joi@10.6.0 upgrade to joi@14.3.1

### DIFF
--- a/packages/cubejs-schema-compiler/package.json
+++ b/packages/cubejs-schema-compiler/package.json
@@ -16,7 +16,7 @@
     "babylon": "^6.17.4",
     "humps": "^2.0.1",
     "inflection": "^1.12.0",
-    "joi": "^10.6.0",
+    "joi": "^14.3.1",
     "moment-range": "^4.0.1",
     "moment-timezone": "^0.5.13",
     "node-dijkstra": "^2.5.0",


### PR DESCRIPTION
resolve #47

Fix dependency warning in schema compiler .

Current ```joi@10.6``` version is deprecated so upgrade to latest ```joi@14.3.1``` .