### PR TITLE
bug : mongobi issue with parsing schema file with nested fields (Scaffoldin…

### DIFF
--- a/packages/cubejs-schema-compiler/scaffolding/ScaffoldingTemplate.js
+++ b/packages/cubejs-schema-compiler/scaffolding/ScaffoldingTemplate.js
@@ -75,7 +75,7 @@ class ScaffoldingTemplate {
   }
 
   memberName(member) {
-    return inflection.camelize(member.title.replace(/\s+/g, '_').toLowerCase(), true);
+    return inflection.camelize(member.title.replace(/\s|\.+/g, '_').toLowerCase(), true);
   }
 
   renderFile(fileDescriptor) {

--- a/packages/cubejs-schema-compiler/scaffolding/ScaffoldingTemplate.js
+++ b/packages/cubejs-schema-compiler/scaffolding/ScaffoldingTemplate.js
@@ -75,7 +75,7 @@ class ScaffoldingTemplate {
   }
 
   memberName(member) {
-    return inflection.camelize(member.title.replace(/\s|\.+/g, '_').toLowerCase(), true);
+    return inflection.camelize(member.title.replace(/\s+|\./g, '_').toLowerCase(), true);
   }
 
   renderFile(fileDescriptor) {


### PR DESCRIPTION
resolve #55 

**Occurence** 
 - Its occurred when we parse nested field's schema. 

**FIX**
  - Ast parser (babylon parser) failed to parse ```any.any``` key syntax so replace ```.``` with ```_``` in ScaffoldingTemplate.