### PR TITLE
Add redshift to postgres driver link

### DIFF
--- a/packages/cubejs-server-core/core/index.js
+++ b/packages/cubejs-server-core/core/index.js
@@ -11,7 +11,8 @@ const DriverDependencies = {
   athena: '@cubejs-backend/athena-driver',
   jdbc: '@cubejs-backend/jdbc-driver',
   mongobi: '@cubejs-backend/mongobi-driver',
-  bigquery: '@cubejs-backend/bigquery-driver'
+  bigquery: '@cubejs-backend/bigquery-driver',
+  redshift: '@cubejs-backend/postgres-driver'
 };
 
 const checkEnvForPlaceholders = () => {


### PR DESCRIPTION
As discussed on slack, this simple change should be enough to enable the support for redshift in the community edition.
https://cube-js.slack.com/archives/CC0403RRR/p1554375237033600?thread_ts=1554352183.032800&cid=CC0403RRR
Please review :)