### PR TITLE
fix(query-orchestrator): add RedisFactory and promisify methods manually

### DIFF
--- a/packages/cubejs-query-orchestrator/orchestrator/RedisCacheDriver.js
+++ b/packages/cubejs-query-orchestrator/orchestrator/RedisCacheDriver.js
@@ -1,21 +1,21 @@
-const redis = require('redis');
+const createRedisClient = require('./RedisFactory');
 
 class RedisCacheDriver {
   constructor() {
-    this.redisClient = redis.createClient(process.env.REDIS_URL);
+    this.redisClient = createRedisClient(process.env.REDIS_URL);
   }
 
   async get(key) {
-    const res = await this.redisClient.getAsync(key);
+    const res = await this.redisClient.get(key);
     return res && JSON.parse(res);
   }
 
   set(key, value, expiration) {
-    return this.redisClient.setAsync(key, JSON.stringify(value), 'EX', expiration);
+    return this.redisClient.set(key, JSON.stringify(value), 'EX', expiration);
   }
 
   remove(key) {
-    return this.redisClient.delAsync(key);
+    return this.redisClient.del(key);
   }
 }
 

--- a/packages/cubejs-query-orchestrator/orchestrator/RedisCacheDriver.js
+++ b/packages/cubejs-query-orchestrator/orchestrator/RedisCacheDriver.js
@@ -6,16 +6,16 @@ class RedisCacheDriver {
   }
 
   async get(key) {
-    const res = await this.redisClient.get(key);
+    const res = await this.redisClient.getAsync(key);
     return res && JSON.parse(res);
   }
 
   set(key, value, expiration) {
-    return this.redisClient.set(key, JSON.stringify(value), 'EX', expiration);
+    return this.redisClient.setAsync(key, JSON.stringify(value), 'EX', expiration);
   }
 
   remove(key) {
-    return this.redisClient.del(key);
+    return this.redisClient.delAsync(key);
   }
 }
 

--- a/packages/cubejs-query-orchestrator/orchestrator/RedisFactory.js
+++ b/packages/cubejs-query-orchestrator/orchestrator/RedisFactory.js
@@ -1,0 +1,14 @@
+const redis = require('redis');
+const { promisify } = require('util');
+
+module.exports = function createRedisClient(url) {
+  redis.Multi.prototype.execAsync = promisify(redis.Multi.prototype.exec);
+
+  const client = redis.createClient(url);
+
+  ['brpop', 'del', 'exec', 'get', 'hget', 'rpop', 'set', 'zadd', 'zrange', 'zrangebyscore'].forEach(
+    k => client[k] = promisify(client[k])
+  );
+
+  return client;
+}

--- a/packages/cubejs-query-orchestrator/orchestrator/RedisFactory.js
+++ b/packages/cubejs-query-orchestrator/orchestrator/RedisFactory.js
@@ -6,8 +6,8 @@ module.exports = function createRedisClient(url) {
 
   const client = redis.createClient(url);
 
-  ['brpop', 'del', 'exec', 'get', 'hget', 'rpop', 'set', 'zadd', 'zrange', 'zrangebyscore'].forEach(
-    k => client[k] = promisify(client[k])
+  ['brpop', 'del', 'get', 'hget', 'rpop', 'set', 'zadd', 'zrange', 'zrangebyscore'].forEach(
+    k => client[`${k}Async`] = promisify(client[k])
   );
 
   return client;

--- a/packages/cubejs-query-orchestrator/orchestrator/RedisQueueDriver.js
+++ b/packages/cubejs-query-orchestrator/orchestrator/RedisQueueDriver.js
@@ -16,13 +16,13 @@ class RedisQueueDriverConnection {
 
   async getResultBlocking(queryKey) {
     const resultListKey = this.resultListKey(queryKey);
-    const result = await this.redisClient.brpop([resultListKey, this.continueWaitTimeout]);
+    const result = await this.redisClient.brpopAsync([resultListKey, this.continueWaitTimeout]);
     return result && JSON.parse(result[1]);
   }
 
   async getResult(queryKey) {
     const resultListKey = this.resultListKey(queryKey);
-    const result = await this.redisClient.rpop(resultListKey);
+    const result = await this.redisClient.rpopAsync(resultListKey);
     return result && JSON.parse(result);
   }
 
@@ -42,11 +42,11 @@ class RedisQueueDriverConnection {
   }
 
   getToProcessQueries() {
-    return this.redisClient.zrange([this.toProcessRedisKey(), 0, -1]);
+    return this.redisClient.zrangeAsync([this.toProcessRedisKey(), 0, -1]);
   }
 
   getActiveQueries() {
-    return this.redisClient.zrange([this.activeRedisKey(), 0, -1]);
+    return this.redisClient.zrangeAsync([this.activeRedisKey(), 0, -1]);
   }
 
   async getQueryAndRemove(queryKey) {
@@ -80,13 +80,13 @@ class RedisQueueDriverConnection {
   }
 
   getOrphanedQueries() {
-    return this.redisClient.zrangebyscore(
+    return this.redisClient.zrangebyscoreAsync(
       [this.recentRedisKey(), 0, (new Date().getTime() - this.orphanedTimeout * 1000)]
     );
   }
 
   getStalledQueries() {
-    return this.redisClient.zrangebyscore(
+    return this.redisClient.zrangebyscoreAsync(
       [this.activeRedisKey(), 0, (new Date().getTime() - this.heartBeatTimeout * 1000)]
     );
   }
@@ -101,12 +101,12 @@ class RedisQueueDriverConnection {
   }
 
   async getQueryDef(queryKey) {
-    const query = await this.redisClient.hget([this.queriesDefKey(), this.redisHash(queryKey)]);
+    const query = await this.redisClient.hgetAsync([this.queriesDefKey(), this.redisHash(queryKey)]);
     return JSON.parse(query);
   }
 
   updateHeartBeat(queryKey) {
-    return this.redisClient.zadd([this.activeRedisKey(), new Date().getTime(), this.redisHash(queryKey)]);
+    return this.redisClient.zaddAsync([this.activeRedisKey(), new Date().getTime(), this.redisHash(queryKey)]);
   }
 
   retrieveForProcessing(queryKey) {

--- a/packages/cubejs-query-orchestrator/package.json
+++ b/packages/cubejs-query-orchestrator/package.json
@@ -11,8 +11,7 @@
   },
   "dependencies": {
     "ramda": "^0.24.1",
-    "redis": "^2.8.0",
-    "util-promisifyall": "^1.0.4"
+    "redis": "^2.8.0"
   },
   "devDependencies": {
     "eslint": "^4.14.0",

--- a/packages/cubejs-query-orchestrator/yarn.lock
+++ b/packages/cubejs-query-orchestrator/yarn.lock
@@ -1009,11 +1009,6 @@ util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-util-promisifyall@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/util-promisifyall/-/util-promisifyall-1.0.4.tgz#82047e87e0637ca799b3480cd6ede3ddeedadf09"
-  integrity sha512-dgR84x56iVKsSMNo5GGED+xciS1bLS84Wsi5sYHW59Wf/P0mVdJckx2o7vLHrChG94J4c/T9EXoRJSoNy6qSEQ==
-
 which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"


### PR DESCRIPTION
Created a simple `RedisFactory` which return a single function `createRedisClient`.

`createRedisClient` takes care of promisifying redis methods.

Was not able to promisify `redis.multi().exec()` without accessing the prototype tho.

I tried to replace `exec` method on `redis.Multi.prototype` and I could not figure out why it was not working. So instead a new `execAsync` method was created

Removed dependency `util-promisifyAll`.

Fixes #84 