### PR TITLE
fix: add the missing @cubejs-client/vue package

### DIFF
--- a/docs/Cube.js-Frontend/@cubejs-client-vue.md
+++ b/docs/Cube.js-Frontend/@cubejs-client-vue.md
@@ -35,7 +35,7 @@ into Vue.js app.
 
 ### Scoped Slot Props
 
-- `measurers`, `dimensions`, `segments`, `timeDimensions`, `filters` - arrays of
+- `measures`, `dimensions`, `segments`, `timeDimensions`, `filters` - arrays of
 selected query builder members.
 - `availableMeasures`, `availableDimensions`, `availableTimeDimensions`,
 `availableSegments` - arrays of available to select members. They are loaded via

--- a/examples/vue-dashboard/frontend/package.json
+++ b/examples/vue-dashboard/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@cubejs-client/core": "^0.4.5",
+    "@cubejs-client/vue": "^0.7.0",
     "chart.js": "^2.8.0",
     "core-js": "^2.6.5",
     "vue": "^2.6.6",


### PR DESCRIPTION
docs: correct typos of the word "measures"