### PR TITLE
Replacing ${TABLE} instances to ${CUBE}

### DIFF
--- a/docs/Schema/Getting-Started-with-Cube.js-Schema.md
+++ b/docs/Schema/Getting-Started-with-Cube.js-Schema.md
@@ -150,7 +150,7 @@ cube(`Users`, {
       sql: `id`,
       type: `count`,
       filters: [
-        { sql: `${TABLE}.paying = 'true'` }
+        { sql: `${CUBE}.paying = 'true'` }
       ]
     },
 

--- a/docs/Schema/cohort-retention.md
+++ b/docs/Schema/cohort-retention.md
@@ -90,7 +90,7 @@ cube(`monthlyRetention`, {
      type: `countDistinct`,
      drillMembers: [Users.id, Users.email],
      filters: [
-       { sql: `${TABLE}.monthly_pageviews > 0`}
+       { sql: `${CUBE}.monthly_pageviews > 0`}
      ]
    },
   
@@ -110,7 +110,7 @@ To be able to build cohorts, we need to group by two dimensions: **signup date**
 cube(`monthlyRetention`, {
  dimensions: {
    monthsSinceSignup: {
-     sql: `DATEDIFF('month', ${TABLE}.signup_month, ${TABLE}.activity_month)`,
+     sql: `DATEDIFF('month', ${CUBE}.signup_month, ${CUBE}.activity_month)`,
      type: `number`
    },
   

--- a/docs/Schema/dimensions.md
+++ b/docs/Schema/dimensions.md
@@ -89,10 +89,10 @@ size: {
   type: `string`,
   case: {
     when: [
-        { sql: `${TABLE}.meta_value = 'xl-en'`, label: `xl` },
-        { sql: `${TABLE}.meta_value = 'xl'`, label: `xl` },
-        { sql: `${TABLE}.meta_value = 'xxl-en'`, label: `xxl` },
-        { sql: `${TABLE}.meta_value = 'xxl'`, label: `xxl` },
+        { sql: `${CUBE}.meta_value = 'xl-en'`, label: `xl` },
+        { sql: `${CUBE}.meta_value = 'xl'`, label: `xl` },
+        { sql: `${CUBE}.meta_value = 'xxl-en'`, label: `xxl` },
+        { sql: `${CUBE}.meta_value = 'xxl'`, label: `xxl` },
     ],
     else: { label: `Unknown` }
   }

--- a/docs/Schema/event-analytics.md
+++ b/docs/Schema/event-analytics.md
@@ -76,7 +76,7 @@ measures: {
     sql: `event_id`,
     type: `count`,
     filters: [
-      { sql: `${TABLE}.event = 'pageview'` }
+      { sql: `${CUBE}.event = 'pageview'` }
     ]
   }
 }
@@ -212,15 +212,15 @@ endRaw: {
 
 endAt: {
   sql:
-`CASE WHEN ${endRaw} + INTERVAL '1 minutes' > ${TABLE}.next_session_start_at
-     THEN ${TABLE}.next_session_start_at
+`CASE WHEN ${endRaw} + INTERVAL '1 minutes' > ${CUBE}.next_session_start_at
+     THEN ${CUBE}.next_session_start_at
      ELSE ${endRaw} + INTERVAL '30 minutes'
      END`,
   type: `time`
 },
 
 durationMinutes: {
-  sql: `datediff(minutes, ${TABLE}.session_start_at, ${endAt})`,
+  sql: `datediff(minutes, ${CUBE}.session_start_at, ${endAt})`,
   type: `number`
 }
 
@@ -276,7 +276,7 @@ Once we have it, we can create a dimension `userId`, which will be either a `use
 ```javascript
 // Add a new dimension to the Sessions cube
 userId: {
-  sql: `coalesce(${Identifies.userId}, ${TABLE}.anonymous_id)`,
+  sql: `coalesce(${Identifies.userId}, ${CUBE}.anonymous_id)`,
   type: `string`
 }
 ```
@@ -365,7 +365,7 @@ Same as for the first referrer. We already have a `session_sequence` field in th
 isFirst: {
   type: `string`,
   case: {
-    when: [{ sql: `${TABLE}.session_sequence = 1`, label: `First`}],
+    when: [{ sql: `${CUBE}.session_sequence = 1`, label: `First`}],
     else: { label: `Repeat` }
   }
 }
@@ -402,7 +402,7 @@ formSubmittedCount: {
   sql: `event_id`,
   type: `count`,
   filters: [
-    { sql: `${TABLE}.event = 'form_submitted'` }
+    { sql: `${CUBE}.event = 'form_submitted'` }
   ]
 }
 ```

--- a/docs/Schema/measures.md
+++ b/docs/Schema/measures.md
@@ -108,7 +108,7 @@ ordersCompletedCount: {
   sql: `id`,
   type: `count`,
   filters: [
-    { sql: `${TABLE}.status = 'completed'` }
+    { sql: `${CUBE}.status = 'completed'` }
   ]
 }
 ```

--- a/docs/Schema/types-and-formats.md
+++ b/docs/Schema/types-and-formats.md
@@ -233,10 +233,10 @@ amount: {
 location: {
   type: `geo`,
   latitude: {
-    sql: `${TABLE}.latitude`,
+    sql: `${CUBE}.latitude`,
   },
   longitude: {
-    sql: `${TABLE}.longitude`
+    sql: `${CUBE}.longitude`
   }
 }
 ```


### PR DESCRIPTION
There is some inconsistency in the docs where at certain places the old `${TABLE}` reference is used, whereas at other places the current `${CUBE}` reference is used