### PR TITLE
Query Join ambiguity with similar column names

### DIFF
--- a/packages/cubejs-schema-compiler/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/adapter/BaseQuery.js
@@ -983,7 +983,7 @@ class BaseQuery {
 
   cubeAlias(cubeName) {
     const prefix = this.safeEvaluateSymbolContext().cubeAliasPrefix || this.cubeAliasPrefix;
-    return this.aliasName(`"${prefix ? prefix + '__' : ''}${cubeName}"`);
+    return this.aliasName(`${prefix ? prefix + '__' : ''}${cubeName}`);
   }
 
   collectCubeNamesFor(fn) {

--- a/packages/cubejs-schema-compiler/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/adapter/BaseQuery.js
@@ -983,7 +983,7 @@ class BaseQuery {
 
   cubeAlias(cubeName) {
     const prefix = this.safeEvaluateSymbolContext().cubeAliasPrefix || this.cubeAliasPrefix;
-    return this.aliasName(`${prefix ? prefix + '__' : ''}${cubeName}`);
+    return this.aliasName(`"${prefix ? prefix + '__' : ''}${cubeName}"`);
   }
 
   collectCubeNamesFor(fn) {

--- a/packages/cubejs-schema-compiler/scaffolding/ScaffoldingSchema.js
+++ b/packages/cubejs-schema-compiler/scaffolding/ScaffoldingSchema.js
@@ -69,7 +69,7 @@ class ScaffoldingSchema {
     }
     if (!this.dbSchema[schema][table]) {
       throw new UserError(`Can't resolve ${tableName}: '${table}' does not exist`);
-    }
+    } 
     return this.dbSchema[schema][table];
   }
 
@@ -148,10 +148,15 @@ class ScaffoldingSchema {
   };
 
   joins(tableName, tableDefinition) {
+    const key = "id";
     return R.unnest(tableDefinition
-      .filter(column => column.name.toLowerCase().indexOf('id') !== -1 && column.name.toLowerCase() !== 'id')
+      .filter(column => {
+        const columnName = column.name.toLowerCase();
+        const columnKeyPosition = columnName.length - columnName.lastIndexOf(key) - key.length;
+        return (columnKeyPosition === 0 && columnName !== 'id')
+      })
       .map(column => {
-        const withoutId = column.name.replace('_id', '').replace('id', '');
+        const withoutId = column.name.replace(new RegExp('_id$', "i"), '').replace(new RegExp('id$', "i"), '');
         const tablesToJoin = this.tableNamesToTables[withoutId] || this.tableNamesToTables[inflection.tableize(withoutId)];
 
         if (!tablesToJoin) {

--- a/packages/cubejs-schema-compiler/scaffolding/ScaffoldingSchema.js
+++ b/packages/cubejs-schema-compiler/scaffolding/ScaffoldingSchema.js
@@ -69,7 +69,7 @@ class ScaffoldingSchema {
     }
     if (!this.dbSchema[schema][table]) {
       throw new UserError(`Can't resolve ${tableName}: '${table}' does not exist`);
-    } 
+    }
     return this.dbSchema[schema][table];
   }
 
@@ -148,15 +148,10 @@ class ScaffoldingSchema {
   };
 
   joins(tableName, tableDefinition) {
-    const key = "id";
     return R.unnest(tableDefinition
-      .filter(column => {
-        const columnName = column.name.toLowerCase();
-        const columnKeyPosition = columnName.length - columnName.lastIndexOf(key) - key.length;
-        return (columnKeyPosition === 0 && columnName !== 'id')
-      })
+      .filter(column => column.name.toLowerCase().indexOf('id') !== -1 && column.name.toLowerCase() !== 'id')
       .map(column => {
-        const withoutId = column.name.replace(new RegExp('_id$', "i"), '').replace(new RegExp('id$', "i"), '');
+        const withoutId = column.name.replace('_id', '').replace('id', '');
         const tablesToJoin = this.tableNamesToTables[withoutId] || this.tableNamesToTables[inflection.tableize(withoutId)];
 
         if (!tablesToJoin) {

--- a/packages/cubejs-schema-compiler/scaffolding/ScaffoldingTemplate.js
+++ b/packages/cubejs-schema-compiler/scaffolding/ScaffoldingTemplate.js
@@ -40,16 +40,16 @@ class ScaffoldingTemplate {
   schemaDescriptorForTable(tableSchema) {
     return {
       cube: tableSchema.cube,
-      sql: `SELECT * FROM "${tableSchema.schema}"."${tableSchema.table}"`, // TODO escape
+      sql: `SELECT * FROM ${tableSchema.schema}.${tableSchema.table}`, // TODO escape
       joins: tableSchema.joins.map(j => ({
         [j.cubeToJoin]: {
-          sql: `\${CUBE}."${j.thisTableColumn}" = \${${j.cubeToJoin}}."${j.columnToJoin}"`,
+          sql: `\${CUBE}.${j.thisTableColumn} = \${${j.cubeToJoin}}.${j.columnToJoin}`,
           relationship: j.relationship
         }
       })).reduce((a, b) => ({ ...a, ...b }), {}),
       measures: tableSchema.measures.map(m => ({
         [this.memberName(m)]: {
-          sql: `\${CUBE}."${m.name}"`,
+          sql: m.name,
           type: m.types[0],
           title: this.memberTitle(m)
         }
@@ -61,7 +61,7 @@ class ScaffoldingTemplate {
       }),
       dimensions: tableSchema.dimensions.map(m => ({
         [this.memberName(m)]: {
-          sql: `\${CUBE}."${m.name}"`,
+          sql: m.name,
           type: m.types[0],
           title: this.memberTitle(m),
           primaryKey: m.isPrimaryKey ? true : undefined

--- a/packages/cubejs-schema-compiler/scaffolding/ScaffoldingTemplate.js
+++ b/packages/cubejs-schema-compiler/scaffolding/ScaffoldingTemplate.js
@@ -49,7 +49,7 @@ class ScaffoldingTemplate {
       })).reduce((a, b) => ({ ...a, ...b }), {}),
       measures: tableSchema.measures.map(m => ({
         [this.memberName(m)]: {
-          sql: `"${m.name}"`,
+          sql: `\${CUBE}."${m.name}"`,
           type: m.types[0],
           title: this.memberTitle(m)
         }
@@ -61,7 +61,7 @@ class ScaffoldingTemplate {
       }),
       dimensions: tableSchema.dimensions.map(m => ({
         [this.memberName(m)]: {
-          sql: `"${m.name}"`,
+          sql: `\${CUBE}."${m.name}"`,
           type: m.types[0],
           title: this.memberTitle(m),
           primaryKey: m.isPrimaryKey ? true : undefined

--- a/packages/cubejs-schema-compiler/scaffolding/ScaffoldingTemplate.js
+++ b/packages/cubejs-schema-compiler/scaffolding/ScaffoldingTemplate.js
@@ -40,16 +40,16 @@ class ScaffoldingTemplate {
   schemaDescriptorForTable(tableSchema) {
     return {
       cube: tableSchema.cube,
-      sql: `SELECT * FROM ${tableSchema.schema}.${tableSchema.table}`, // TODO escape
+      sql: `SELECT * FROM "${tableSchema.schema}"."${tableSchema.table}"`, // TODO escape
       joins: tableSchema.joins.map(j => ({
         [j.cubeToJoin]: {
-          sql: `\${CUBE}.${j.thisTableColumn} = \${${j.cubeToJoin}}.${j.columnToJoin}`,
+          sql: `\${CUBE}."${j.thisTableColumn}" = \${${j.cubeToJoin}}."${j.columnToJoin}"`,
           relationship: j.relationship
         }
       })).reduce((a, b) => ({ ...a, ...b }), {}),
       measures: tableSchema.measures.map(m => ({
         [this.memberName(m)]: {
-          sql: m.name,
+          sql: `\${CUBE}."${m.name}"`,
           type: m.types[0],
           title: this.memberTitle(m)
         }
@@ -61,7 +61,7 @@ class ScaffoldingTemplate {
       }),
       dimensions: tableSchema.dimensions.map(m => ({
         [this.memberName(m)]: {
-          sql: m.name,
+          sql: `\${CUBE}."${m.name}"`,
           type: m.types[0],
           title: this.memberTitle(m),
           primaryKey: m.isPrimaryKey ? true : undefined

--- a/packages/cubejs-schema-compiler/scaffolding/ScaffoldingTemplate.js
+++ b/packages/cubejs-schema-compiler/scaffolding/ScaffoldingTemplate.js
@@ -40,16 +40,16 @@ class ScaffoldingTemplate {
   schemaDescriptorForTable(tableSchema) {
     return {
       cube: tableSchema.cube,
-      sql: `SELECT * FROM ${tableSchema.schema}.${tableSchema.table}`, // TODO escape
+      sql: `SELECT * FROM "${tableSchema.schema}"."${tableSchema.table}"`, // TODO escape
       joins: tableSchema.joins.map(j => ({
         [j.cubeToJoin]: {
-          sql: `\${CUBE}.${j.thisTableColumn} = \${${j.cubeToJoin}}.${j.columnToJoin}`,
+          sql: `\${CUBE}."${j.thisTableColumn}" = \${${j.cubeToJoin}}."${j.columnToJoin}"`,
           relationship: j.relationship
         }
       })).reduce((a, b) => ({ ...a, ...b }), {}),
       measures: tableSchema.measures.map(m => ({
         [this.memberName(m)]: {
-          sql: m.name,
+          sql: `"${m.name}"`,
           type: m.types[0],
           title: this.memberTitle(m)
         }
@@ -61,7 +61,7 @@ class ScaffoldingTemplate {
       }),
       dimensions: tableSchema.dimensions.map(m => ({
         [this.memberName(m)]: {
-          sql: m.name,
+          sql: `"${m.name}"`,
           type: m.types[0],
           title: this.memberTitle(m),
           primaryKey: m.isPrimaryKey ? true : undefined


### PR DESCRIPTION
Column name ambiguity issue during table joins with similar column names fix by forcing the alias for column names